### PR TITLE
tweetsテーブルからnameカラムを削除

### DIFF
--- a/db/migrate/20220212011404_remove_name_from_tweets.rb
+++ b/db/migrate/20220212011404_remove_name_from_tweets.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromTweets < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :tweets, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_03_145829) do
+ActiveRecord::Schema.define(version: 2022_02_12_011404) do
 
   create_table "tweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
     t.string "text"
     t.text "image"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
rails g migration RemoveNameFromTweets name:string

rails db:migrate